### PR TITLE
🔧: Remove mime dependency and use XFile mime value

### DIFF
--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -1,6 +1,5 @@
 import 'package:cross_file/cross_file.dart';
 import 'package:flutter/widgets.dart';
-import 'package:mime/mime.dart';
 
 import '../messages/form_messages.dart';
 import '../models/validator.dart';
@@ -155,9 +154,7 @@ class MimeTypeValidator extends Validator<XFile> {
   @override
   ValidatorFn<XFile> get validator {
     return (XFile? value) {
-      final fileType = lookupMimeType(value?.path ?? '');
-
-      if (value != null && !mimeType.contains(fileType)) {
+      if (value != null && !mimeType.contains(value.mimeType)) {
         return message ?? errorCode;
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks: ">=0.18.4 <1.0.0"
-  mime: ">=1.0.4 <3.0.0"
   path: ^1.9.1
   source_gen: ">=1.2.0 <3.0.0"
 


### PR DESCRIPTION
`MimeTypeValidator` was not working on web because it was using the lookupMimeType method from mime package. Problem is that, when a file is uploaded from web, is it a blob and the file type does not appear in path.

Validation was therefore compromised.
